### PR TITLE
Add 2 open-source tools + ThatDevPro HTTP/HTML reference library

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A curated list of backlink, social signal opportunities, social media marketing,
 - [BuiltWith](https://builtwith.com/) -- Find out what websites are built with.
 - [httpstatus.io is a popular bulk HTTP status checker, redirect checker and header checker.](https://httpstatus.io/)
 - [Local SERP Checker: Check Google SERPs for any keyword. View localized search results for any country, city or ZIP code on Google and Google Maps.](https://www.brightlocal.com/local-search-results-checker/)
+- [ThatDevPro HTTP Headers Reference](https://www.thatdevpro.com/reference/) -- 8 canonical references for diagnosing crawler signals: caching, content, CORS, performance, rate-control, request, security, and SEO headers, plus all HTTP status code families (2xx-5xx).
 
 # SEO Tools
 - [SERP Preview: Preview how your page could look in search results.](https://seotoolbelt.co/tools/serp-preview/)
@@ -230,6 +231,8 @@ A curated list of backlink, social signal opportunities, social media marketing,
 - [MonsterInsights.com Headline Analyzer tool enables you to write irresistible SEO headlines that drive traffic, shares, and rank better in search results.](https://www.monsterinsights.com/headline-analyzer/)
 - [SiteLiner: Siteliner is a free service that lets you explore your website, revealing key issues that affect your site's quality and search engine rankings:](https://www.siteliner.com/)
 - [Simple ML for Sheets](https://workspace.google.com/marketplace/app/simple_ml_for_sheets/) -- "With Simple ML for Sheets everyone can use Machine Learning in Google Sheets without knowing ML, without coding, and without sharing data with third parties."
+- [aio-surfaces](https://github.com/Janady13/aio-surfaces) -- Open-source MIT Python toolkit. Generates `llms.txt`, `aeo.json`, `entity.json`, and `brand.json` from a single typed site config — the four AI-citation surfaces.
+- [seo-sidecar](https://github.com/Janady13/seo-sidecar) -- FastAPI + nginx SSI sidecar that injects fresh Schema.org JSON-LD into nginx-served sites without redeploys. MIT licensed.
 
 # On-Page SEO Tools
 - [Moz.com SEO Learning Center -> On-Site SEO -> Title Tag -> Title Tag Preview Tool](https://moz.com/learn/seo/title-tag)


### PR DESCRIPTION
Three additions across two relevant sections:

**Technical SEO Testing Tools**:

- [ThatDevPro HTTP Headers Reference](https://www.thatdevpro.com/reference/) — 8 canonical reference pages for diagnosing crawler signals: caching, content, CORS, performance, rate-control, request, security, and SEO headers, plus all HTTP status code families (2xx-5xx). Paired with 12 HTML meta-tag reference pages.

**SEO Tools**:

- [aio-surfaces](https://github.com/Janady13/aio-surfaces) — Open-source MIT Python toolkit. Generates `llms.txt`, `aeo.json`, `entity.json`, and `brand.json` from a single typed site config. Same code powering thatdevpro.com.
- [seo-sidecar](https://github.com/Janady13/seo-sidecar) — FastAPI + nginx SSI sidecar that injects fresh Schema.org JSON-LD into nginx-served sites without redeploys. Pure Python + Go, MIT licensed.

All real production tools, not scaffolds. The reference library serves as troubleshooting docs for diagnosing crawler issues, complementing existing list entries like KeyCDN tools and httpstatus.io.